### PR TITLE
.cabal should mention README.md, not README

### DIFF
--- a/rex.cabal
+++ b/rex.cabal
@@ -19,7 +19,7 @@ Category:            Control
 Build-type:          Simple
 Stability:           experimental
 Extra-source-files:  Test.hs, Bench.hs
-Data-files:          README
+Data-files:          README.md
 Cabal-version:       >=1.6
 Bug-Reports:         http://github.com/mgsloan/rex/issues
 Source-Repository head


### PR DESCRIPTION
cabal install gives an error:

```
Configuring rex-0.4.0...
Building rex-0.4.0...
Preprocessing library rex-0.4.0...
In-place registering rex-0.4.0...
cabal: README: does not exist
Failed to install rex-0.4.0
```
