### PR TITLE
Fix Builds With Template Haskell v2.18+

### DIFF
--- a/Text/Regex/PCRE/Rex.hs
+++ b/Text/Regex/PCRE/Rex.hs
@@ -289,7 +289,12 @@ makePat :: RexConf -> ParseChunks -> PatQ
 makePat conf (cnt, pat, exs) = do
   viewExp <- buildExp conf cnt pat $ map (fmap fst) views
   return . ViewP viewExp
-         . (\xs -> ConP 'Just [TupP xs])
+         . (\xs -> ConP 'Just
+#if MIN_VERSION_template_haskell(2,18,0)
+                []
+#endif
+                [TupP xs]
+            )
          . map snd $ catMaybes views
  where
   views :: [Maybe (Exp, Pat)]


### PR DESCRIPTION
Hey, would love to get `rex` into Stackage nightly, but it currently fails to build against template-haskell 2.18+. This CPP conditional should fix compilation, the `ConP` constructor was modified to require a list of type applications as well. I don't think any are necessary so I passed in an empty list:

https://hackage.haskell.org/package/template-haskell-2.18.0.0/docs/Language-Haskell-TH.html#t:Pat

Could we get a version bump + new release after this is merged? I can then make a PR to stackage to get this into nightly & the next LTS.

Thanks!